### PR TITLE
Add Network policy for the llm-monitoring.

### DIFF
--- a/charts/all/rag-llm/templates/llm-monitoring-networkpolicy.yaml
+++ b/charts/all/rag-llm/templates/llm-monitoring-networkpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.customnetworkpolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-llm-monitoring-ns
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: llm-monitoring
+  policyTypes:
+    - Ingress
+{{- end }}

--- a/charts/all/rag-llm/templates/populate-vectordb-job.yaml
+++ b/charts/all/rag-llm/templates/populate-vectordb-job.yaml
@@ -2,9 +2,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name:  populate-vectordb-{{ include "rag-llm.fullname" . }}
-  annotations:
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
   labels:
     {{- include "rag-llm.labels" . | nindent 4 }}
 spec:

--- a/charts/all/rag-llm/values.yaml
+++ b/charts/all/rag-llm/values.yaml
@@ -175,8 +175,6 @@ populateDbJob:
   doc_dir: /docs
 
 
-
-
   # By default, fullname uses '{{ .Release.Name }}-{{ .Chart.Name }}'. This
   # overrides that and uses the given string instead.
   # fullnameOverride: "some-name"
@@ -222,3 +220,7 @@ secretStore:
 
 hfmodel:
   key: secret/data/hub/hfmodel
+
+# Create NetworkPolicy to allow traffic to llm-monitoring namespace. Set to false if monitoring is not needed
+customnetworkpolicy:
+  enabled: true


### PR DESCRIPTION
Network policy to allow prometheus scraping from llm-monitoring namespace . Can be disabled using values . Additionally remove argocd hook for populate database job to make it regular object